### PR TITLE
Исправления false-positive обнаружение леммы

### DIFF
--- a/src/main/java/me/bazhenov/aot/Lemma.java
+++ b/src/main/java/me/bazhenov/aot/Lemma.java
@@ -1,13 +1,10 @@
 package me.bazhenov.aot;
 
-import com.google.common.base.Objects;
-
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.Sets.newHashSet;
 import static java.util.Collections.emptySet;
 import static java.util.Objects.requireNonNull;
@@ -92,5 +89,12 @@ public class Lemma {
 
 	public Set<String> getPrefixes() {
 		return prefixes;
+	}
+
+	public boolean hasFlexionBy(String preffix, String suffix) {
+		return flexions.stream()
+			.anyMatch(f -> (isNullOrEmpty(preffix) || preffix.equals(f.getPrefix()) &&
+				suffix.equals(f.getEnding())
+			));
 	}
 }

--- a/src/main/java/me/bazhenov/aot/MapDictionary.java
+++ b/src/main/java/me/bazhenov/aot/MapDictionary.java
@@ -15,6 +15,7 @@ import static java.lang.Integer.parseInt;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singleton;
 import static java.util.Collections.unmodifiableMap;
+import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 import static java.util.stream.IntStream.range;
 import static java.util.stream.IntStream.rangeClosed;
@@ -924,7 +925,7 @@ public class MapDictionary implements Dictionary {
 		Map<String, String> prefixesPostfixes = rangeClosed(0, sufix.length())
 			.boxed()
 			.filter(i -> allEndings.contains(sufix.substring(i, sufix.length())))
-			.collect(Collectors.toMap(
+			.collect(toMap(
 				index -> sufix.substring(0, index),
 				index -> sufix.substring(index, sufix.length())));
 
@@ -932,6 +933,7 @@ public class MapDictionary implements Dictionary {
 		return byBaseIn.stream()
 			.filter(l -> (isNullOrEmpty(preffix) || l.getPrefixes().contains(preffix)) &&
 				l.getEndings().contains(prefixesPostfixes.get(l.getBase())))
+			.filter(l -> l.hasFlexionBy(preffix, prefixesPostfixes.get(l.getBase())))
 			.collect(toSet());
 	}
 }

--- a/src/test/java/me/bazhenov/aot/MapDictionaryTest.java
+++ b/src/test/java/me/bazhenov/aot/MapDictionaryTest.java
@@ -94,4 +94,10 @@ public class MapDictionaryTest {
 		Set<Lemma> lemmas = dict.lookupWord("серобуромалиновый");
 		assertThat(lemmas, hasSize(1));
 	}
+
+	@Test
+	public void testLookupPreffixAndEndingsFromDifferentFlexion() throws Exception {
+		Set<Lemma> lemmas = dict.lookupWord("поклейка");
+		assertThat(lemmas, empty());
+	}
 }


### PR DESCRIPTION
Ошибка встречается при попытке поиска леммы с префиксом из одного склонения, а окончанием из другого. Яркий пример - при попытке поиска слова "поклейка" найдется лемма, у которой имются склонения с префиксом "по", основанием "клей", суффиксом "йка", однако не проверяется, что эта комбинация встречается в рамках одного склонения.
